### PR TITLE
Refactor rules

### DIFF
--- a/tests/scoring/test_rules.py
+++ b/tests/scoring/test_rules.py
@@ -25,21 +25,16 @@ def test_score_multiples_rule(seq, expected):
     result = rule.score(dice=dice)
     assert result == expected
 
-@pytest.mark.parametrize("seq, override, expected", [
-    ([1,2,3,4,5], None, 0),
-    ([1,1,3,4,5], None, 0),
-    ([1,1,1,4,5], None, 12),
-    ([1,1,1,1,5], None, 9),
-    ([1,1,1,1,1], None, 5),
-    ([1,2,3,4,5], 20, 0),
-    ([1,1,3,4,5], 20, 0),
-    ([1,1,1,4,5], 20, 20),
-    ([1,1,1,1,5], 20, 20),
-    ([1,1,1,1,1], 20, 20),
+@pytest.mark.parametrize("seq, expected", [
+    ([1,2,3,4,5], 0),
+    ([1,1,3,4,5], 0),
+    ([1,1,1,4,5], 12),
+    ([1,1,1,1,5], 9),
+    ([1,1,1,1,1], 5),
 ])
-def test_score_nkind_rule(seq, override, expected):
+def test_score_nkind_rule(seq, expected):
     dice = [Die(starting_face=s) for s in seq]
-    rule = rules.NofKindScoringRule(name="name", n=3, override_score=override)
+    rule = rules.NofKindScoringRule(name="name", n=3)
     result = rule.score(dice=dice)
     assert result == expected
 

--- a/tests/scoring/test_rules.py
+++ b/tests/scoring/test_rules.py
@@ -9,6 +9,7 @@ import pytest
     ([2,2,3,4,5], 16),
 ])
 def test_score_chance_rule(seq, expected):
+    """Check that Chance rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.ChanceScoringRule(name="name")
     result = rule.score(dice=dice)
@@ -20,6 +21,7 @@ def test_score_chance_rule(seq, expected):
     ([2,2,3,4,5], 4),
 ])
 def test_score_multiples_rule(seq, expected):
+    """Check that Multiples rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.MultiplesScoringRule(name="name", face_value=2)
     result = rule.score(dice=dice)
@@ -33,6 +35,7 @@ def test_score_multiples_rule(seq, expected):
     ([1,1,1,1,1], 5),
 ])
 def test_score_nkind_rule(seq, expected):
+    """Check that N-of-a-Kind rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.NofKindScoringRule(name="name", n=3)
     result = rule.score(dice=dice)
@@ -59,6 +62,7 @@ def test_score_yahtzee_rule(seq, expected):
     ([1,1,2,2,2], 5),
 ])
 def test_score_full_house_rule(seq, expected):
+    """Check that Full House rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.FullHouseScoringRule(name="name", score_value = 5)
     result = rule.score(dice=dice)
@@ -70,6 +74,7 @@ def test_score_full_house_rule(seq, expected):
     ([1,1,2,3,4], 0),
 ])
 def test_score_large_straight_rule(seq, expected):
+    """Check that Large Straight rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.LargeStraightScoringRule(name="name", score_value = 5)
     result = rule.score(dice=dice)
@@ -81,6 +86,7 @@ def test_score_large_straight_rule(seq, expected):
     ([1,1,2,3,4], 5),
 ])
 def test_score_small_straight_rule(seq, expected):
+    """Check that Small Straight rules score correctly."""
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.SmallStraightScoringRule(name="name", score_value = 5)
     result = rule.score(dice=dice)
@@ -92,6 +98,7 @@ def test_score_small_straight_rule(seq, expected):
     ([1,1,1,4,5], 12),
 ])
 def test_sum_all_showing_faces(seq, expected):
+    """Check that showing faces are summed correctly."""
     dice = [Die(starting_face=s) for s in seq]
     result = rules._sum_all_showing_faces(dice=dice)
     assert result == expected
@@ -102,6 +109,7 @@ def test_sum_all_showing_faces(seq, expected):
     ([1,1,2,2,2], 3, 0),
 ])
 def test_sum_all_showing_faces(seq, face, expected):
+    """Check that matching showing faces are summed correctly."""
     dice = [Die(starting_face=s) for s in seq]
     result = rules._sum_matching_faces(dice=dice, face_value=face)
     assert result == expected

--- a/tests/scoring/test_rules.py
+++ b/tests/scoring/test_rules.py
@@ -42,6 +42,20 @@ def test_score_nkind_rule(seq, expected):
     ([1,2,3,4,5], 0),
     ([1,1,3,4,5], 0),
     ([1,1,1,4,5], 0),
+    ([1,1,1,1,5], 0),
+    ([1,1,1,1,1], 5),
+])
+def test_score_yahtzee_rule(seq, expected):
+    """Check that Yahtzee rules score correctly."""
+    dice = [Die(starting_face=s) for s in seq]
+    rule = rules.YahtzeeScoringRule(name="name", score_value=5)
+    result = rule.score(dice=dice)
+    assert result == expected
+
+@pytest.mark.parametrize("seq, expected", [
+    ([1,2,3,4,5], 0),
+    ([1,1,3,4,5], 0),
+    ([1,1,1,4,5], 0),
     ([1,1,2,2,2], 5),
 ])
 def test_score_full_house_rule(seq, expected):
@@ -70,4 +84,24 @@ def test_score_small_straight_rule(seq, expected):
     dice = [Die(starting_face=s) for s in seq]
     rule = rules.SmallStraightScoringRule(name="name", score_value = 5)
     result = rule.score(dice=dice)
+    assert result == expected
+
+@pytest.mark.parametrize("seq, expected", [
+    ([1,2,3,4,5], 15),
+    ([1,1,3,4,5], 14),
+    ([1,1,1,4,5], 12),
+])
+def test_sum_all_showing_faces(seq, expected):
+    dice = [Die(starting_face=s) for s in seq]
+    result = rules._sum_all_showing_faces(dice=dice)
+    assert result == expected
+
+@pytest.mark.parametrize("seq, face, expected", [
+    ([1,1,2,2,2], 1, 2),
+    ([1,1,2,2,2], 2, 6),
+    ([1,1,2,2,2], 3, 0),
+])
+def test_sum_all_showing_faces(seq, face, expected):
+    dice = [Die(starting_face=s) for s in seq]
+    result = rules._sum_matching_faces(dice=dice, face_value=face)
     assert result == expected

--- a/yahtzee/scoring/rules.py
+++ b/yahtzee/scoring/rules.py
@@ -23,107 +23,153 @@ class Section(Enum):
     LOWER: str = "lower"
 
 class ScoringRule(ABC):
-    """Abstract class for a scoring rule."""
+    """Generic scoring rule."""
+    def __init__(self, name: str, section: Section):
+        self.name = name
+        self.section = section
+
     @abstractmethod
     def score(self, dice: List[Die]) -> int:
         """Method to score a given set of dice."""
         pass
 
-class ChanceScoringRule(ScoringRule):
+class PatternConstantScoringRule(ScoringRule):
+    """Generic scoring rule, which looks for a particular pattern,
+    and has a constant score value."""
+    def __init__(self, name: str, section: Section, score_value: int = None):
+        super().__init__(name=name, section=section)
+        self.score_value = score_value
+
+    def score(self, dice: List[Die]) -> int:
+        """Method to score a given set of dice."""
+        if self.validate(dice=dice):
+            return self.score_value
+        else:
+            return 0
+
+    @abstractmethod
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        pass
+
+class PatternVariableScoringRule(ScoringRule):
+    """Generic scoring rule, which looks for a particular pattern,
+    and has a constant score value."""
+    def __init__(self, name: str, section: Section):
+        super().__init__(name=name, section=section)
+
+    def score(self, dice: List[Die]) -> int:
+        """Method to score a given set of dice."""
+        if self.validate(dice=dice):
+            return self._scoring_func(dice=dice)
+        else:
+            return 0
+
+    @abstractmethod
+    def _scoring_func(self, dice: List[Die]) -> int:
+        """Method for calculating a dice-dependent score."""
+        pass
+
+    @abstractmethod
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        pass
+
+class ChanceScoringRule(PatternVariableScoringRule):
     """Rules which take any 5 dice."""
     def __init__(self, name: str, section: Section = Section.LOWER):
-        self.name = name
-        self.section = section
+        super().__init__(name=name, section=section)
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scores as the total of all dice."""
-        return sum([die.showing_face for die in dice])
+    def _scoring_func(self, dice: List[Die]) -> int:
+        """Method for calculating a dice-dependent score."""
+        return _sum_all_showing_faces(dice=dice)
 
-class MultiplesScoringRule(ScoringRule):
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        # Any dice combo is valid
+        return True
+
+class MultiplesScoringRule(PatternVariableScoringRule):
     """Rules which look for multiple dice with a specific face value."""
     def __init__(self, name: str, face_value: int, section: Section = Section.UPPER):
-        self.name = name
+        super().__init__(name=name, section=section)
         self.face_value = face_value
-        self.section = section
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scores as total of dice with the matching face value."""
-        matching_dice = _find_matching_dice(dice=dice, face_value=self.face_value)
-        return self.face_value * len(matching_dice)
+    def _scoring_func(self, dice: List[Die]) -> int:
+        """Method for calculating a dice-dependent score."""
+        return _sum_matching_faces(dice=dice, face_value=self.face_value)
 
-class NofKindScoringRule(ScoringRule):
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        # Any dice combo is valid
+        return True
+
+class NofKindScoringRule(PatternVariableScoringRule):
     """Rules which look for n-of-a-kind of a face value, without explicitly
     specifying the desired face value."""
-    def __init__(self, name: str, n: int, section: Section = Section.LOWER, override_score: Optional[int] = None):
-        self.name = name
+    def __init__(self, name: str, n: int, section: Section = Section.LOWER):
+        super().__init__(name=name, section=section)
         self.n = n
-        self.section = section
-        self.override_score = override_score
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scores as total of all dice, given that the n-of-a-kind is present.
-        Allows for a custom score value to be used (i.e., Yahtzee is worth 50)."""
-        # check that n-of-a-kind is present, or any n-of-a-kind larger than n
-        n_or_more_kind_present = any([
+    def _scoring_func(self, dice: List[Die]) -> int:
+        """Method for calculating a dice-dependent score."""
+        return _sum_all_showing_faces(dice=dice)
+
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        n_or_more_kind_present = [
             _validate_nofkind(dice=dice, n=x)
             for x in range(self.n, len(dice) + 1)
-        ])
-        if n_or_more_kind_present:
-            if self.override_score:
-                score = self.override_score
-            else:
-                score = sum([die.showing_face for die in dice])
-        else:
-            score = 0
-        return score
+        ]
+        return any(n_or_more_kind_present)
 
-class FullHouseScoringRule(ScoringRule):
+class YahtzeeScoringRule(PatternConstantScoringRule):
+    """Rules which look for a Yahtzee (5-of-a-kind)."""
+    def __init__(self, name: str, section: Section = Section.LOWER, score_value: int = SCORE_YAHTZEE):
+        super().__init__(name=name, section=section, score_value=score_value)
+
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that the desired pattern
+        is present in the given dice."""
+        return _validate_nofkind(dice=dice, n=5)
+
+class FullHouseScoringRule(PatternConstantScoringRule):
     """Rules which look for a full house (3-of-a-kind and 2-of-a-kind)."""
     def __init__(self, name: str, section: Section = Section.LOWER, score_value: int = SCORE_FULL_HOUSE):
-        self.name = name
-        self.section = section
-        self.score_value = score_value
+        super().__init__(name=name, section=section, score_value=score_value)
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scores as SCORE_FULL_HOUSE, given that a full house is present."""
-        if _validate_full_house(dice=dice):
-            score = self.score_value
-        else:
-            score = 0
-        return score
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that a full house is present in the given dice."""
+        return _validate_full_house(dice=dice)
 
-class LargeStraightScoringRule(ScoringRule):
+class LargeStraightScoringRule(PatternConstantScoringRule):
     """Rules which look for a large straight (5 dice sequence)."""
     def __init__(self, name: str, section: Section = Section.LOWER, score_value: int = SCORE_LARGE_STRAIGHT):
-        self.name = name
-        self.section = section
-        self.score_value = score_value
+        super().__init__(name=name, section=section, score_value=score_value)
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scored as SCORE_LARGE_STRAIGHT, given that a large straight is present."""
-        if _validate_large_straight(dice=dice):
-            score = self.score_value
-        else:
-            score = 0
-        return score
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that a full house is present in the given dice."""
+        return _validate_large_straight(dice=dice)
 
-class SmallStraightScoringRule(ScoringRule):
+class SmallStraightScoringRule(PatternConstantScoringRule):
     """Rules which look for a small straight (4 dice sequence)."""
     def __init__(self, name: str, section: Section = Section.LOWER, score_value: int = SCORE_SMALL_STRAIGHT):
-        self.name = name
-        self.section = section
-        self.score_value = score_value
+        super().__init__(name=name, section=section, score_value=score_value)
 
-    def score(self, dice: List[Die]) -> int:
-        """Method to score a given set of dice.
-        Scored as SCORE_SMALL_STRAIGHT, given that a small straight is present."""
-        if _validate_small_straight(dice=dice):
-            score = self.score_value
-        else:
-            score = 0
-        return score
+    def validate(self, dice: List[Die]) -> bool:
+        """Method to check that a full house is present in the given dice."""
+        return _validate_small_straight(dice=dice)
+
+def _sum_all_showing_faces(dice: List[Die]) -> int:
+    """Sums all the showing faces for a set of dice."""
+    return sum([die.showing_face for die in dice])
+
+def _sum_matching_faces(dice: List[Die], face_value: int) -> int:
+    """Sums all the showing faces which match a given value for a set of dice."""
+    matching_dice = _find_matching_dice(dice=dice, face_value=face_value)
+    return _sum_all_showing_faces(dice=matching_dice)

--- a/yahtzee/scoring/rules.py
+++ b/yahtzee/scoring/rules.py
@@ -55,7 +55,7 @@ class PatternConstantScoringRule(ScoringRule):
 
 class PatternVariableScoringRule(ScoringRule):
     """Generic scoring rule, which looks for a particular pattern,
-    and has a constant score value."""
+    and has a variable score value."""
     def __init__(self, name: str, section: Section):
         super().__init__(name=name, section=section)
 
@@ -170,6 +170,6 @@ def _sum_all_showing_faces(dice: List[Die]) -> int:
     return sum([die.showing_face for die in dice])
 
 def _sum_matching_faces(dice: List[Die], face_value: int) -> int:
-    """Sums all the showing faces which match a given value for a set of dice."""
+    """Sums all the showing faces which match a given value, for a set of dice."""
     matching_dice = _find_matching_dice(dice=dice, face_value=face_value)
     return _sum_all_showing_faces(dice=matching_dice)

--- a/yahtzee/yahtzee.py
+++ b/yahtzee/yahtzee.py
@@ -15,6 +15,6 @@ DEFAULT_RULES = [
     rules.FullHouseScoringRule(name="Full House"),
     rules.SmallStraightScoringRule(name="Small Straight"),
     rules.LargeStraightScoringRule(name="Large Straight"),
-    rules.NofKindScoringRule(name="YAHTZEE", n=5, override_score=rules.SCORE_YAHTZEE),
+    rules.YahtzeeScoringRule(name="YAHTZEE"),
     rules.ChanceScoringRule(name="Chance"),
 ]


### PR DESCRIPTION
Implements another abstraction layer for rules.

Previously, all rules inherited from `ScoringRule`, which was pretty bare-bones, so all subsequent classes had to define several common methods. Now, the immediate sub-classes are `PatternConstantScoringRule` and `PatternVariableScoringRule`, which define some common abstract methods, allowing the actual rule classes to implement their specific logic, while simplifying the common logic via inheritance.

Also moved the rule for Yahtzees from a special case of `NofKindScoringRule` that used an override value, to a proper sub-class of `PatternConstantScoringRule` (`YahtzeeScoringRule`), which uses the same validation function as `NofKindScoringRule`.