### PR TITLE
Refactor Terminal Methods

### DIFF
--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -46,7 +46,7 @@ def test_game_init():
 
 @pytest.mark.parametrize("choices, expected", [
     ([2], [1, 2, 2]),
-    ([3], [1, 2, 3]),
+    (None, [1, 2, 3]),
     ([0, 2], [2, 2, 2]),
 ])
 def test_reroll_dice(monkeypatch, choices, expected):
@@ -83,40 +83,38 @@ def test_game_score_rule(monkeypatch):
 
 
 @pytest.mark.parametrize("selected", [
+    (0,),
     (1,),
     (2,),
-    (3,),
+    (0, 1),
+    (0, 2),
     (1, 2),
-    (1, 3),
-    (2, 3),
-    (1, 2, 3),
-    (4,),
+    (0, 1, 2),
 ])
 def test_pick_reroll_dice(monkeypatch, selected):
     """Check that dice are selected correctly."""
     dice = [Die() for _ in range(3)]
 
-    # Mocking TerminalMenu reduces the usefulness of this test,
-    # but just mocking TermainalMenu.show() fails on some systems
-    # because of errors thrown during TermainalMenu.__init__().
-    # Not sure of the exact cause, and I can get the mocked
-    # TerminalMenu.show() to work fine on my system, but this
-    # at least tests the conversion from the TerminalMenu.show()
-    # output tuple to the desired list, if nothing else.
-    class MockTerminalMenu:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def show(self):
-            return selected
-
     monkeypatch.setattr(
-        "yahtzee.game.TerminalMenu",
-        lambda *args, **kwargs: MockTerminalMenu()
+        "yahtzee.game.mutliple_choice_from_menu",
+        lambda **kwargs: selected
     )
     result = gm._pick_reroll_dice(dice=dice)
 
     assert sorted(result) == sorted(list(selected))
+
+
+def test_pick_reroll_dice_none(monkeypatch):
+    """Check that None is returned when no dice are selected."""
+    dice = [Die() for _ in range(3)]
+
+    monkeypatch.setattr(
+        "yahtzee.game.mutliple_choice_from_menu",
+        lambda **kwargs: (3,)
+    )
+    result = gm._pick_reroll_dice(dice=dice)
+
+    assert result is None
 
 
 @pytest.mark.parametrize("selected", range(3))
@@ -130,23 +128,9 @@ def test_pick_rule_to_score(monkeypatch, selected):
 
     dice = [Die() for _ in range(5)]
 
-    # Mocking TerminalMenu reduces the usefulness of this test,
-    # but just mocking TermainalMenu.show() fails on some systems
-    # because of errors thrown during TermainalMenu.__init__().
-    # Not sure of the exact cause, and I can get the mocked
-    # TerminalMenu.show() to work fine on my system, but this
-    # at least tests the conversion from the TerminalMenu.show()
-    # output tuple to the desired list, if nothing else.
-    class MockTerminalMenu:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def show(self):
-            return selected
-
     monkeypatch.setattr(
-        "yahtzee.game.TerminalMenu",
-        lambda *args, **kwargs: MockTerminalMenu()
+        "yahtzee.game.single_choice_from_menu",
+        lambda **kwargs: selected
     )
     result = gm._pick_rule_to_score(rules=rules, dice=dice)
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,58 @@
+import yahtzee.terminal as tm
+
+import pytest
+from abc import ABC, abstractmethod
+
+
+# Since these functions use `TerminalMenu`, these tests are pretty trivial.
+# They mostly just check that the return values are correct.
+# On my machine, using `monkeypatch.setattr` on  `TerminalMenu.show()`
+# works just fine, but not so on other machines - namely, the build agent
+# used in GitHub Actions.
+# For now, this will at least give some testing for the module, if not much.
+class MockTerminalMenu(ABC):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def show(self):
+        pass
+
+
+@pytest.mark.parametrize("selected", range(3))
+def test_single_choice_from_menu(monkeypatch, selected):
+    """Check that a single-choice menu returns the correct value."""
+    choices = ["a", "b", "c"]
+
+    class MockTerminalMenuSingle(MockTerminalMenu):
+        def show(self):
+            return selected
+
+    monkeypatch.setattr(
+        "yahtzee.terminal.TerminalMenu",
+        lambda *args, **kwargs: MockTerminalMenuSingle()
+    )
+
+    result = tm.single_choice_from_menu(choices=choices)
+
+    assert result == selected
+
+
+def test_mutliple_choice_from_menu(monkeypatch):
+    """Check that a multi-choice menu returns the correct value."""
+    choices = ["a", "b", "c"]
+
+    selected = (0, 1)
+
+    class MockTerminalMenuMultiple(MockTerminalMenu):
+        def show(self):
+            return selected
+
+    monkeypatch.setattr(
+        "yahtzee.terminal.TerminalMenu",
+        lambda *args, **kwargs: MockTerminalMenuMultiple()
+    )
+
+    result = tm.mutliple_choice_from_menu(choices=choices)
+
+    assert result == selected

--- a/yahtzee/game.py
+++ b/yahtzee/game.py
@@ -3,11 +3,10 @@ from .scoring import rules as rl
 from .scoring.scoresheet import Scoresheet
 from .players import Player
 from .dice import Die
+from .terminal import single_choice_from_menu, mutliple_choice_from_menu
 
 from copy import deepcopy
-from typing import List, Optional, Tuple
-
-from simple_term_menu import TerminalMenu  # type: ignore
+from typing import List, Optional
 
 
 class Game:
@@ -102,8 +101,7 @@ class Game:
         """
         dice_to_reroll = _pick_reroll_dice(dice=player.dice)
 
-        # if no dice are selected, the index should be out-of-range
-        if max(dice_to_reroll) < len(player.dice):
+        if dice_to_reroll:
             player.roll_dice(dice=dice_to_reroll)
 
         return None
@@ -128,7 +126,7 @@ class Game:
         return None
 
 
-def _pick_reroll_dice(dice: List[Die]) -> List[int]:
+def _pick_reroll_dice(dice: List[Die]) -> Optional[List[int]]:
     """Gets user input for which dice to re-roll.
 
     Parameters
@@ -146,18 +144,16 @@ def _pick_reroll_dice(dice: List[Die]) -> List[int]:
     dice_choices = [str(die.showing_face) for die in dice]
     dice_choices = dice_choices + ["None"]
 
-    dice_menu = TerminalMenu(
-        dice_choices,
+    selected_indexes = mutliple_choice_from_menu(
+        choices=dice_choices,
         title="Pick which dice to re-roll (if any).",
-        multi_select=True,
-        show_multi_select_hint=True,
-        multi_select_select_on_accept=False,
-        cursor_index=len(dice_choices),
+        cursor_end=True,
     )
 
-    selected_indexes: Tuple[int] = dice_menu.show()
-
-    return list(selected_indexes)
+    if any([dice_choices[c] == "None" for c in selected_indexes]):
+        return None
+    else:
+        return list(selected_indexes)
 
 
 def _pick_rule_to_score(rules: List[rl.ScoringRule], dice: List[Die]) -> str:
@@ -181,8 +177,6 @@ def _pick_rule_to_score(rules: List[rl.ScoringRule], dice: List[Die]) -> str:
     dice_faces = sorted(dice_faces)
     menu_title = f"Pick which rule to score for the dice: {','.join(dice_faces)}."
 
-    rule_menu = TerminalMenu(rule_choices, title=menu_title)
-
-    selected_index: int = rule_menu.show()
+    selected_index = single_choice_from_menu(choices=rule_choices, title=menu_title)
 
     return rule_choices[selected_index]

--- a/yahtzee/terminal.py
+++ b/yahtzee/terminal.py
@@ -1,0 +1,66 @@
+from typing import List, Tuple
+
+from simple_term_menu import TerminalMenu  # type: ignore
+
+
+def single_choice_from_menu(
+    choices: List[str],
+    title: str = "Pick one from:",
+) -> int:
+    """Presents the user with a menu and returns the index of the user's choice.
+
+    Parameters
+    ----------
+    choices : list of str
+        The choices to present to the user.
+    title : str, default "Pick one from:"
+        The title to show for the menu.
+
+    Returns
+    -------
+    choice : int
+        The index of the selected choice.
+    """
+    menu = TerminalMenu(choices, title=title)
+    selected: int = menu.show()
+
+    return selected
+
+
+def mutliple_choice_from_menu(
+    choices: List[str],
+    title: str = "Pick any number of the following:",
+    cursor_end: bool = True,
+) -> Tuple[int]:
+    """Presents the user with a menu and returns the index of the user's choices.
+
+    Parameters
+    ----------
+    choices : list of str
+        The choices to present to the user.
+    title : str, default "Pick any number of the following:"
+        The title to show for the menu.
+    cursor_end : bool, default True
+        Whether to start the cursor at the end of the list.
+        Defaults to True.
+        If False, the cursor will start at the beginning of the list.
+
+    Returns
+    -------
+    choices : tuple of int
+        The indexes of the selected choice(s).
+    """
+    cursor_index = len(choices) if cursor_end else 0
+
+    menu = TerminalMenu(
+        choices,
+        title=title,
+        multi_select=True,
+        show_multi_select_hint=True,
+        multi_select_select_on_accept=False,
+        cursor_index=cursor_index,
+    )
+
+    selected: Tuple[int] = menu.show()
+
+    return selected


### PR DESCRIPTION
- Moves terminal-specific code (mainly user-input menus from `simple_term_menu`) into a separate module
- Adjusts how some choices are returned from menus
  - If no selections are made for a multi-select list, `None` is returned